### PR TITLE
Fix Patient entity

### DIFF
--- a/src/database/entity/Patient.ts
+++ b/src/database/entity/Patient.ts
@@ -11,8 +11,9 @@ export default class Patient extends User {
     @Column({ length: 11 })
     public citizenId: string = '';
 
-    @Column({ type: "timestamp without time zone" })
-    public dateOfBirth: number;
+    // dateOfBirth is Unix Timestamp (seconds since 01.01.1970(UTC))
+    @Column({ type: "integer", default: 0 })
+    public dateOfBirth: number = 0;
 
     @OneToMany(type => Appointment, appointments => appointments.patient)
     public appointments: Appointment[];


### PR DESCRIPTION
Przed merge'm i akceptacją proszę o rzucenie okiem czy na pewno dobrze myślę, ale teraz serwer działa poprawnie, więc chyba to była przyczyna błędów z rejestracją pacjenta.
Frontend działał z myślą o Unix Timestamp (w sekundach) i takie dane wysyłał, z kolei backend miał błąd polegający na błędnym typie kolumny, którym było Postgresowe Timestamp (string, a nie liczba).